### PR TITLE
Fixing build on platforms other than *nix

### DIFF
--- a/fontdirs_darwin.go
+++ b/fontdirs_darwin.go
@@ -6,5 +6,5 @@
 package findfont
 
 func getFontDirectories() (paths []string) {
-	return []string{expandUser("~/Library/Fonts/", "/Library/Fonts/")}
+	return []string{expandUser("~/Library/Fonts/"), "/Library/Fonts/"}
 }

--- a/fontdirs_unix.go
+++ b/fontdirs_unix.go
@@ -1,3 +1,5 @@
+// +build dragonfly freebsd linux nacl netbsd openbsd solaris
+
 // Copyright 2016 Florian Pigorsch. All rights reserved.
 //
 // Use of this source code is governed by a MIT-style


### PR DESCRIPTION
Adding conditional compilation build tags for fontdirs-unix.go fixing build on platforms other than *nix