### PR TITLE
Fixing build on platforms other than *nix

### DIFF
--- a/fontdirs_darwin.go
+++ b/fontdirs_darwin.go
@@ -6,5 +6,5 @@
 package findfont
 
 func getFontDirectories() (paths []string) {
-	return []string{expandUser("~/Library/Fonts/", "/Library/Fonts/")}
+	return []string{expandUser("~/Library/Fonts/"), "/Library/Fonts/"}
 }

--- a/fontdirs_unix.go
+++ b/fontdirs_unix.go
@@ -1,3 +1,5 @@
+// +build dragonfly freebsd linux nacl netbsd openbsd solaris
+
 // Copyright 2016 Florian Pigorsch. All rights reserved.
 //
 // Use of this source code is governed by a MIT-style


### PR DESCRIPTION
Fixed build issues that occur on Windows due to _Unix files not being excluded from the build, and fixed Darwin build issues due to expandUser including two string when it should have been one