### PR TITLE
Add Windows user font directory

### DIFF
--- a/fontdirs_windows.go
+++ b/fontdirs_windows.go
@@ -11,5 +11,8 @@ import (
 )
 
 func getFontDirectories() (paths []string) {
-	return []string{filepath.Join(os.Getenv("windir"), "Fonts")}
+	return []string{
+		filepath.Join(os.Getenv("windir"), "Fonts"),
+		filepath.Join(os.Getenv("localappdata"), "Microsoft", "Windows", "Fonts"),
+	}
 }


### PR DESCRIPTION
Starting from Windows 10 1809, fonts will be installed into `%LOCALAPPDATA%\Microsoft\Windows\Fonts` by default to allow font installation for non-admin users (see Microsoft's [blog post](https://blogs.windows.com/windowsexperience/2018/06/27/announcing-windows-10-insider-preview-build-17704/)).