### PR TITLE
Fix default font directory list on MacOS Catalina

### DIFF
--- a/fontdirs_darwin.go
+++ b/fontdirs_darwin.go
@@ -6,5 +6,9 @@
 package findfont
 
 func getFontDirectories() (paths []string) {
-	return []string{expandUser("~/Library/Fonts/"), "/Library/Fonts/"}
+	return []string{
+		expandUser("~/Library/Fonts/"),
+		"/Library/Fonts/",
+		"/System/Library/Fonts/",
+	}
 }


### PR DESCRIPTION
After I upgraded to MacOS Catalina, I've noticed that Arial fonts could not be detected anymore. I've figured out that Arial and some other font were moved to `/System/Library/Fonts/`.

I don't know whether it is a proper fix, but it solved the issue for me.