### PR TITLE
js/wasm compilation supported for web

### DIFF
--- a/fontdirs_js.go
+++ b/fontdirs_js.go
@@ -1,0 +1,10 @@
+// Copyright 2016 Florian Pigorsch. All rights reserved.
+//
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package findfont
+
+func getFontDirectories() (paths []string) {
+	return nil
+}


### PR DESCRIPTION
though it is meaningless in a web page, this is needed to compile with wasm (javascript support).
tested with `fyne package -os web`