### PR TITLE
js/wasm compilation supported for web

### DIFF
--- a/fontdirs_js.go
+++ b/fontdirs_js.go
@@ -1,0 +1,10 @@
+// Copyright 2016 Florian Pigorsch. All rights reserved.
+//
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package findfont
+
+func getFontDirectories() (paths []string) {
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bon-ami/go-findfont
+module github.com/flopp/go-findfont
 
 go 1.22

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/flopp/go-findfont
+module github.com/bon-ami/go-findfont
 
 go 1.22


### PR DESCRIPTION
though it is meaningless in a web page, this is needed to compile with wasm (javascript support).
tested with fyne package -os web